### PR TITLE
Ajout de la commande /anonymous pour envoie de message anonyme

### DIFF
--- a/commands/utility/anonymous.js
+++ b/commands/utility/anonymous.js
@@ -1,0 +1,97 @@
+const {
+  SlashCommandBuilder,
+  PermissionFlagsBits,
+  ChannelType,
+  EmbedBuilder,
+} = require("discord.js");
+
+// Empêche les pings @everyone, @here, rôles et users (normalement)
+function sanitizeForNoPings(text) {
+  return text
+    .replaceAll(/@everyone/gi, "@\u200beveryone")
+    .replaceAll(/@here/gi, "@\u200bhere")
+    .replaceAll(/<@&/g, "<@\u200b&")
+    .replaceAll(/<@!/g, "<@\u200b!")
+    .replaceAll(/<@/g, "<@\u200b");
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName("anonymous")
+    .setDescription(
+      "Envoie anonymement un message via le bot dans ce salon ou un autre."
+    )
+    .addStringOption((option) =>
+      option
+        .setName("message")
+        .setDescription("Le contenu du message anonyme")
+        .setRequired(true)
+        .setMaxLength(2000)
+    )
+    .addChannelOption((option) =>
+      option
+        .setName("salon")
+        .setDescription(
+          "Salon cible (par défaut : celui où la commande est exécutée)"
+        )
+        .addChannelTypes(ChannelType.GuildText)
+        .setRequired(false)
+    ),
+
+  async execute(interaction) {
+    const raw = interaction.options.getString("message", true);
+    const targetChannel =
+      interaction.options.getChannel("salon") || interaction.channel;
+
+    // Vérif du type de salon
+    if (!targetChannel || targetChannel.type !== ChannelType.GuildText) {
+      return interaction.reply({
+        content:
+          "Je ne peux envoyer des messages que dans un salon textuel du serveur.",
+        ephemeral: true,
+      });
+    }
+
+    // Vérif permissions d’envoi pour le bot
+    const perms = targetChannel.permissionsFor(interaction.client.user.id);
+    if (!perms || !perms.has(PermissionFlagsBits.SendMessages)) {
+      return interaction.reply({
+        content:
+          "Je n’ai pas la permission d’envoyer des messages dans ce salon.",
+        ephemeral: true,
+      });
+    }
+
+    const content = sanitizeForNoPings(raw);
+
+    try {
+      await targetChannel.send({
+        content,
+        allowedMentions: { parse: [], repliedUser: false }, // anti-pings au cas où
+      });
+
+      // Confirmation éphémère stylée
+      const confirm = new EmbedBuilder()
+        .setColor(0x2ecc71)
+        .setTitle("✅ Message anonyme envoyé")
+        .setDescription(
+          targetChannel.id === interaction.channelId
+            ? "Ton message a été posté anonymement dans ce salon."
+            : `Ton message a été posté anonymement dans <#${targetChannel.id}>.`
+        )
+        .setFooter({
+          text: "Bot Discord 3SIB",
+          iconURL: interaction.client.user.displayAvatarURL(),
+        })
+        .setTimestamp();
+
+      await interaction.reply({ embeds: [confirm], ephemeral: true });
+    } catch (err) {
+      console.error("Anonymous send error:", err);
+      await interaction.reply({
+        content: "Une erreur est survenue lors de l’envoi du message.",
+        ephemeral: true,
+      });
+    }
+  },
+};


### PR DESCRIPTION
# 🎭 Commande `/anonymous` — Envoi de messages anonymes

## Contexte

Ajout d’une commande slash permettant aux membres d’envoyer un message **anonyme** via le bot, dans le salon courant ou un salon cible, avec protections anti-mentions et confirmation éphémère.

## Résumé des changements

* **Nouvelle commande** `commands/anonymous.js` (CommonJS) :

  * Option `message` (*string*, **obligatoire**, max 2000).
  * Option `salon` (*channel textuel*, optionnel).
  * Envoi du message via le bot dans le salon choisi.
  * Neutralisation des mentions (`@everyone`, `@here`, rôles, users).
  * Confirmation à l’auteur via un **Embed** en **éphémère**.
  * Respect des permissions : vérifie `SendMessages` sur le salon cible.


## Détails d’implémentation

* Sanitation des mentions via un helper `sanitizeForNoPings()`.
* Validation du type de salon (`ChannelType.GuildText`) et des permissions du bot.
* Utilisation d’un **embed** de confirmation : succès, cible affichée, footer “Bot Discord 3SIB”, timestamp.

## Steps de test (manuels)

1. **Déploiement des commandes**

   ```
   npm run deploy
   ```
2. **Démarrer le bot**

   ```
   npm start
   ```
3. **Cas nominal**

   * `/anonymous message:"Ceci est un test anonyme"`
     → Le bot poste le message dans le salon courant, l’auteur reçoit une confirmation éphémère.
4. **Salon cible**

   * `/anonymous message:"Hello #général" salon:#général`
     → Le message apparaît dans `#général`, confirmation éphémère.
5. **Anti-mentions**

   * Message contenant `@everyone`, `@here`, `@role` ou `@user`
     → Les mentions sont neutralisées (pas de ping).
6. **Permissions manquantes**

   * Retirer “Envoyer des messages” au bot sur un salon test
     → La commande répond en éphémère : pas de permission.
7. **Longueur**

   * Message > 2000 caractères → refusé par la validation d’option.

## Checklist

* [ ] Commande déployée sur **GUILD** de test (dev).
* [ ] Tests manuels réalisés (cas nominal, salon cible, anti-mentions, permissions).
* [ ] Lint/format OK.
* [ ] Logs : pas d’info personnelle persistée (respect de l’anonymat).
* [ ] Aucun secret en clair dans le code.

## Sécurité & Permissions

* Le bot n’envoie le message que si `SendMessages` est accordé sur le salon cible.
* Mentions neutralisées pour éviter les abus (@everyone/@here/mentions forcées).
* La réponse au user est **éphémère** (ne révèle pas l’identité).

## Impacts & risques

* Risque d’usage abusif (spam/harcèlement).
  → Mesures prévues : anti-mentions, respect des permissions, possibilité future d’ajouter un cooldown/ratelimit/modo-only.
* Pas de breaking change sur les autres commandes.

## Suivi / Évolutions possibles

* Ajout d’un **cooldown** utilisateur ou d’un quota par salon.
* Option booléenne “autoriser les mentions” (par défaut off).
* Audit log privé pour le staff (opt-in, à discuter car diminue l’anonymat).
* Paramètre de destination par défaut configurable (ex. salon “confessionnal”).


