### PR TITLE
Add ban, kick, unban, and banlist commands with button interactions

### DIFF
--- a/commands/utility/ban.js
+++ b/commands/utility/ban.js
@@ -1,0 +1,89 @@
+const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+
+module.exports = {
+	data: new SlashCommandBuilder()
+		.setName('ban')
+		.setDescription('Bannit un membre du serveur')
+		.addUserOption(option =>
+			option
+				.setName('membre')
+				.setDescription('Le membre à bannir')
+				.setRequired(true))
+		.addStringOption(option =>
+			option
+				.setName('raison')
+				.setDescription('La raison du bannissement')
+				.setRequired(false))
+		.addIntegerOption(option =>
+			option
+				.setName('duree_suppression')
+				.setDescription('Nombre de jours de messages à supprimer (0-7)')
+				.setMinValue(0)
+				.setMaxValue(7)
+				.setRequired(false))
+		.setDefaultMemberPermissions(PermissionFlagsBits.BanMembers)
+		.setDMPermission(false),
+	async execute(interaction) {
+		const membre = interaction.options.getMember('membre');
+		const utilisateur = interaction.options.getUser('membre');
+		const raison = interaction.options.getString('raison') || 'Aucune raison fournie';
+		const dureeSuppression = interaction.options.getInteger('duree_suppression') || 0;
+
+		// Vérifications de sécurité
+		if (membre) {
+			if (membre.id === interaction.user.id) {
+				return interaction.reply({
+					content: '❌ Vous ne pouvez pas vous bannir vous-même !',
+					ephemeral: true
+				});
+			}
+
+			if (membre.id === interaction.client.user.id) {
+				return interaction.reply({
+					content: '❌ Je ne peux pas me bannir moi-même !',
+					ephemeral: true
+				});
+			}
+
+			if (!membre.bannable) {
+				return interaction.reply({
+					content: '❌ Je ne peux pas bannir ce membre. Il a peut-être un rôle supérieur au mien.',
+					ephemeral: true
+				});
+			}
+
+			if (interaction.member.roles.highest.position <= membre.roles.highest.position) {
+				return interaction.reply({
+					content: '❌ Vous ne pouvez pas bannir ce membre car il a un rôle égal ou supérieur au vôtre.',
+					ephemeral: true
+				});
+			}
+		}
+
+		try {
+			// Tenter d'envoyer un message privé au membre avant de le bannir
+			if (membre) {
+				await membre.send(`Vous avez été banni de **${interaction.guild.name}** pour la raison suivante : ${raison}`).catch(() => {
+					// Ignorer si l'envoi échoue (DM fermés)
+				});
+			}
+
+			// Bannir le membre
+			await interaction.guild.members.ban(utilisateur, {
+				reason: raison,
+				deleteMessageSeconds: dureeSuppression * 24 * 60 * 60
+			});
+
+			await interaction.reply({
+				content: `✅ **${utilisateur.tag}** a été banni du serveur.\n**Raison :** ${raison}\n**Messages supprimés :** ${dureeSuppression} jour(s)`,
+				ephemeral: false
+			});
+		} catch (error) {
+			console.error('Erreur lors du bannissement :', error);
+			await interaction.reply({
+				content: '❌ Une erreur est survenue lors du bannissement du membre.',
+				ephemeral: true
+			});
+		}
+	},
+};

--- a/commands/utility/banlist.js
+++ b/commands/utility/banlist.js
@@ -1,0 +1,62 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+
+module.exports = {
+	data: new SlashCommandBuilder()
+		.setName('banlist')
+		.setDescription('Affiche la liste des utilisateurs bannis du serveur')
+		.setDefaultMemberPermissions(PermissionFlagsBits.BanMembers)
+		.setDMPermission(false),
+	async execute(interaction) {
+		try {
+			await interaction.deferReply({ ephemeral: true });
+
+			const bans = await interaction.guild.bans.fetch();
+
+			if (bans.size === 0) {
+				return interaction.editReply({
+					content: '✅ Aucun utilisateur n\'est actuellement banni sur ce serveur.'
+				});
+			}
+
+			const embed = new EmbedBuilder()
+				.setColor(0xFF0000)
+				.setTitle('📋 Liste des utilisateurs bannis')
+				.setDescription(`Il y a actuellement **${bans.size}** utilisateur(s) banni(s) sur ce serveur.`)
+				.setTimestamp();
+
+			// Créer une liste des utilisateurs bannis
+			const banList = Array.from(bans.values());
+			let description = '';
+
+			for (let i = 0; i < Math.min(banList.length, 25); i++) {
+				const ban = banList[i];
+				const reason = ban.reason || 'Aucune raison fournie';
+				
+				embed.addFields({
+					name: `${i + 1}. ${ban.user.tag}`,
+					value: `**ID:** \`${ban.user.id}\`\n**Raison:** ${reason}`,
+					inline: false
+				});
+			}
+
+			if (bans.size > 25) {
+				embed.setFooter({ 
+					text: `Affichage de 25 sur ${bans.size} bannis. Utilisez /unban pour débannir un utilisateur.` 
+				});
+			} else {
+				embed.setFooter({ 
+					text: 'Utilisez /unban <user_id> pour débannir un utilisateur.' 
+				});
+			}
+
+			await interaction.editReply({
+				embeds: [embed]
+			});
+		} catch (error) {
+			console.error('Erreur lors de la récupération de la liste des bannis :', error);
+			await interaction.editReply({
+				content: '❌ Une erreur est survenue lors de la récupération de la liste des bannis.'
+			});
+		}
+	},
+};

--- a/commands/utility/kick.js
+++ b/commands/utility/kick.js
@@ -1,0 +1,80 @@
+const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+
+module.exports = {
+	data: new SlashCommandBuilder()
+		.setName('kick')
+		.setDescription('Expulse un membre du serveur')
+		.addUserOption(option =>
+			option
+				.setName('membre')
+				.setDescription('Le membre à expulser')
+				.setRequired(true))
+		.addStringOption(option =>
+			option
+				.setName('raison')
+				.setDescription('La raison de l\'expulsion')
+				.setRequired(false))
+		.setDefaultMemberPermissions(PermissionFlagsBits.KickMembers)
+		.setDMPermission(false),
+	async execute(interaction) {
+		const membre = interaction.options.getMember('membre');
+		const raison = interaction.options.getString('raison') || 'Aucune raison fournie';
+
+		// Vérifications de sécurité
+		if (!membre) {
+			return interaction.reply({
+				content: '❌ Le membre spécifié n\'est pas sur ce serveur.',
+				ephemeral: true
+			});
+		}
+
+		if (membre.id === interaction.user.id) {
+			return interaction.reply({
+				content: '❌ Vous ne pouvez pas vous expulser vous-même !',
+				ephemeral: true
+			});
+		}
+
+		if (membre.id === interaction.client.user.id) {
+			return interaction.reply({
+				content: '❌ Je ne peux pas m\'expulser moi-même !',
+				ephemeral: true
+			});
+		}
+
+		if (!membre.kickable) {
+			return interaction.reply({
+				content: '❌ Je ne peux pas expulser ce membre. Il a peut-être un rôle supérieur au mien.',
+				ephemeral: true
+			});
+		}
+
+		if (interaction.member.roles.highest.position <= membre.roles.highest.position) {
+			return interaction.reply({
+				content: '❌ Vous ne pouvez pas expulser ce membre car il a un rôle égal ou supérieur au vôtre.',
+				ephemeral: true
+			});
+		}
+
+		try {
+			// Tenter d'envoyer un message privé au membre avant de l'expulser
+			await membre.send(`Vous avez été expulsé de **${interaction.guild.name}** pour la raison suivante : ${raison}`).catch(() => {
+				// Ignorer si l'envoi échoue (DM fermés)
+			});
+
+			// Expulser le membre
+			await membre.kick(raison);
+
+			await interaction.reply({
+				content: `✅ **${membre.user.tag}** a été expulsé du serveur.\n**Raison :** ${raison}`,
+				ephemeral: false
+			});
+		} catch (error) {
+			console.error('Erreur lors de l\'expulsion :', error);
+			await interaction.reply({
+				content: '❌ Une erreur est survenue lors de l\'expulsion du membre.',
+				ephemeral: true
+			});
+		}
+	},
+};

--- a/commands/utility/unban.js
+++ b/commands/utility/unban.js
@@ -1,0 +1,126 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+
+module.exports = {
+	data: new SlashCommandBuilder()
+		.setName('unban')
+		.setDescription('Débannit un utilisateur du serveur')
+		.addStringOption(option =>
+			option
+				.setName('user_id')
+				.setDescription('L\'ID de l\'utilisateur à débannir (optionnel si vous utilisez les boutons)')
+				.setRequired(false))
+		.addStringOption(option =>
+			option
+				.setName('raison')
+				.setDescription('La raison du débannissement')
+				.setRequired(false))
+		.setDefaultMemberPermissions(PermissionFlagsBits.BanMembers)
+		.setDMPermission(false),
+	async execute(interaction) {
+		const userId = interaction.options.getString('user_id');
+		const raison = interaction.options.getString('raison') || 'Aucune raison fournie';
+
+		// Si un ID est fourni, débannir directement
+		if (userId) {
+			// Vérifier si l'ID est valide (nombre)
+			if (!/^\d+$/.test(userId)) {
+				return interaction.reply({
+					content: '❌ L\'ID fourni n\'est pas valide. Veuillez fournir un ID d\'utilisateur valide.',
+					ephemeral: true
+				});
+			}
+
+			try {
+				// Récupérer la liste des bannissements
+				const bans = await interaction.guild.bans.fetch();
+				const bannedUser = bans.find(ban => ban.user.id === userId);
+
+				if (!bannedUser) {
+					return interaction.reply({
+						content: '❌ Cet utilisateur n\'est pas banni sur ce serveur.',
+						ephemeral: true
+					});
+				}
+
+				// Débannir l'utilisateur
+				await interaction.guild.members.unban(userId, raison);
+
+				await interaction.reply({
+					content: `✅ **${bannedUser.user.tag}** (${userId}) a été débanni du serveur.\n**Raison :** ${raison}`,
+					ephemeral: false
+				});
+			} catch (error) {
+				console.error('Erreur lors du débannissement :', error);
+				
+				if (error.code === 10026) {
+					return interaction.reply({
+						content: '❌ Utilisateur inconnu. Vérifiez l\'ID fourni.',
+						ephemeral: true
+					});
+				}
+
+				await interaction.reply({
+					content: '❌ Une erreur est survenue lors du débannissement de l\'utilisateur.',
+					ephemeral: true
+				});
+			}
+		} else {
+			// Afficher la liste des bannis avec des boutons
+			try {
+				const bans = await interaction.guild.bans.fetch();
+
+				if (bans.size === 0) {
+					return interaction.reply({
+						content: '✅ Aucun utilisateur n\'est actuellement banni sur ce serveur.',
+						ephemeral: true
+					});
+				}
+
+				const embed = new EmbedBuilder()
+					.setColor(0x00FF00)
+					.setTitle('📋 Liste des utilisateurs bannis')
+					.setDescription('Cliquez sur un bouton pour débannir un utilisateur.')
+					.setFooter({ text: `Total: ${bans.size} utilisateur(s) banni(s)` });
+
+				// Créer des boutons pour chaque utilisateur banni (maximum 5 par page)
+				const bansArray = Array.from(bans.values()).slice(0, 25); // Discord limite à 25 boutons par message
+				const rows = [];
+				
+				for (let i = 0; i < Math.min(bansArray.length, 25); i++) {
+					const ban = bansArray[i];
+					embed.addFields({
+						name: `${i + 1}. ${ban.user.tag}`,
+						value: `ID: \`${ban.user.id}\`\nRaison: ${ban.reason || 'Aucune raison'}`,
+						inline: true
+					});
+
+					// Créer une ligne avec un bouton
+					const row = new ActionRowBuilder()
+						.addComponents(
+							new ButtonBuilder()
+								.setCustomId(`unban_${ban.user.id}`)
+								.setLabel(`Débannir ${ban.user.username}`)
+								.setStyle(ButtonStyle.Success)
+						);
+					rows.push(row);
+				}
+
+				if (bans.size > 25) {
+					embed.setDescription(`Cliquez sur un bouton pour débannir un utilisateur.\n⚠️ Seulement les 25 premiers bannis sont affichés.`);
+				}
+
+				await interaction.reply({
+					embeds: [embed],
+					components: rows.slice(0, 5), // Discord limite à 5 ActionRows
+					ephemeral: true
+				});
+			} catch (error) {
+				console.error('Erreur lors de la récupération des bannis :', error);
+				await interaction.reply({
+					content: '❌ Une erreur est survenue lors de la récupération de la liste des bannis.',
+					ephemeral: true
+				});
+			}
+		}
+	},
+};

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -37,10 +37,54 @@ module.exports = {
             }
         }
         
-        // Gestion des boutons (pour de futures fonctionnalités)
+        // Gestion des boutons
         else if (interaction.isButton()) {
             console.log(`🔘 ${interaction.user.tag} a cliqué sur le bouton: ${interaction.customId}`);
-            // Ajouter ici la logique pour les boutons
+            
+            // Gestion du bouton de débannissement
+            if (interaction.customId.startsWith('unban_')) {
+                const userId = interaction.customId.replace('unban_', '');
+                
+                try {
+                    // Vérifier les permissions
+                    if (!interaction.member.permissions.has('BanMembers')) {
+                        return interaction.reply({
+                            content: '❌ Vous n\'avez pas la permission de débannir des membres.',
+                            ephemeral: true
+                        });
+                    }
+
+                    // Récupérer les informations de l'utilisateur banni
+                    const bans = await interaction.guild.bans.fetch();
+                    const bannedUser = bans.find(ban => ban.user.id === userId);
+
+                    if (!bannedUser) {
+                        return interaction.reply({
+                            content: '❌ Cet utilisateur n\'est plus banni.',
+                            ephemeral: true
+                        });
+                    }
+
+                    // Débannir l'utilisateur
+                    await interaction.guild.members.unban(userId, `Débanni par ${interaction.user.tag}`);
+
+                    await interaction.reply({
+                        content: `✅ **${bannedUser.user.tag}** a été débanni du serveur avec succès !`,
+                        ephemeral: false
+                    });
+
+                    // Désactiver le bouton après utilisation
+                    await interaction.message.edit({
+                        components: []
+                    });
+                } catch (error) {
+                    console.error('Erreur lors du débannissement:', error);
+                    await interaction.reply({
+                        content: '❌ Une erreur est survenue lors du débannissement.',
+                        ephemeral: true
+                    });
+                }
+            }
         }
         
         // Gestion des menus déroulants (pour de futures fonctionnalités)


### PR DESCRIPTION
This pull request introduces comprehensive moderation commands for banning, kicking, and unbanning users, as well as listing banned members, with robust permission checks and user feedback. It also adds interactive unban functionality via Discord buttons, improving the moderation workflow and user experience.

### Moderation command additions

* Added a new `/ban` command in `ban.js` that allows moderators to ban users with options for specifying the reason and the number of days of message deletion, including safety checks to prevent misuse and informative feedback for both the moderator and the banned user.
* Added a `/kick` command in `kick.js` for expelling users from the server, with similar safety checks and user notifications as the ban command.

### Ban management improvements

* Added a `/banlist` command in `banlist.js` to display an embed listing all banned users, including their IDs and ban reasons, with support for up to 25 users per page and guidance for unbanning.
* Added an `/unban` command in `unban.js` that allows moderators to unban users by ID or via interactive buttons for recently banned users, with error handling and feedback for invalid IDs or unbanned users.

### Interactive unban via buttons

* Implemented button handling in `interactionCreate.js` to allow moderators to unban users directly from the ban list embed by clicking a button, with permission checks, feedback, and automatic disabling of the button after use.